### PR TITLE
Latitude and longitude values ignored

### DIFF
--- a/djangocms_maps/static/djangocms_maps/js/bingmaps.js
+++ b/djangocms_maps/static/djangocms_maps/js/bingmaps.js
@@ -71,6 +71,8 @@ djangocms.Maps = {
 
         // latitute or longitute have precedence over the address when provided
         // inside the plugin form
+        data.lat = data.lat.toString();
+        data.lng = data.lng.toString();
         if (data.lat.length && data.lng.length) {
             var coords = {
                 lat: parseFloat(data.lat.replace(',', '.')),

--- a/djangocms_maps/static/djangocms_maps/js/googlemaps.js
+++ b/djangocms_maps/static/djangocms_maps/js/googlemaps.js
@@ -67,6 +67,8 @@ djangocms.Maps = {
 
         // latitute or longitute have presedence over the address when provided
         // inside the plugin form
+        data.lat = data.lat.toString();
+        data.lng = data.lng.toString();
         if (data.lat.length && data.lng.length) {
             var latlng = {
                 lat: parseFloat(data.lat.replace(',', '.')),

--- a/djangocms_maps/static/djangocms_maps/js/here.js
+++ b/djangocms_maps/static/djangocms_maps/js/here.js
@@ -90,6 +90,8 @@ djangocms.Maps = {
 
         // latitute or longitute have precedence over the address when provided
         // inside the plugin form
+        data.lat = data.lat.toString();
+        data.lng = data.lng.toString();
         if (data.lat.length && data.lng.length) {
             var latlng = {
                 lat: parseFloat(data.lat.replace(',', '.')),

--- a/djangocms_maps/static/djangocms_maps/js/mapbox.js
+++ b/djangocms_maps/static/djangocms_maps/js/mapbox.js
@@ -84,6 +84,8 @@ djangocms.Maps = {
 
         // latitute or longitute have precedence over the address when provided
         // inside the plugin form
+        data.lat = data.lat.toString();
+        data.lng = data.lng.toString();
         if (data.lat.length && data.lng.length) {
             var latlng = {
                 lat: parseFloat(data.lat.replace(',', '.')),

--- a/djangocms_maps/static/djangocms_maps/js/viamichelin.js
+++ b/djangocms_maps/static/djangocms_maps/js/viamichelin.js
@@ -70,6 +70,8 @@ djangocms.Maps = {
 
         // latitute or longitute have precedence over the address when provided
         // inside the plugin form
+        data.lat = data.lat.toString();
+        data.lng = data.lng.toString();
         if (data.lat.length && data.lng.length) {
             options.center = {
                 coords: {


### PR DESCRIPTION
Length attribute in condition `if (data.lat.length && data.lng.length) {` is undefined when jQuery parses data-lat or data-lng as float:

```
$('<div data-lat="19.137943"></div>').data('lat').length
> undefined
```