### PR TITLE
ImportError with python_2_unicode_compatible on django-cms 3.8.0

### DIFF
--- a/djangocms_maps/models.py
+++ b/djangocms_maps/models.py
@@ -5,7 +5,10 @@ from django.db import models
 from django.utils.translation import ugettext_lazy as _
 
 from cms.models import CMSPlugin
-from cms.utils.compat.dj import python_2_unicode_compatible
+try:
+    from cms.utils.compat.dj import python_2_unicode_compatible
+except ImportError:
+    from django.utils.six import python_2_unicode_compatible
 
 from .settings import PROVIDERS
 


### PR DESCRIPTION
You're currently importing python_2_unicode_compatible from cms.utils.compat.dj (of which the source code can be found [here](https://github.com/django-cms/django-cms/blob/develop/cms/utils/compat/dj.py). This has been depreciated, so throws an import error with the newest djangocms version, which makes the plugin unusable, so instead I'm importing it from django.utils.six. 
An other option would be to import it directly from six (`from six import python_2_unicode_compatible`) but this would require another dependency.  